### PR TITLE
Detect perf format with file header comments

### DIFF
--- a/lib/detect-inputtype.js
+++ b/lib/detect-inputtype.js
@@ -7,7 +7,7 @@ var perfRegex = /^\w+ +\d+ +\d+\.\d+:/;
 
 function firstLine(arr) {
   for (var i = 0; i < arr.length; i++) {
-    if (arr[i] && arr[i].length) return arr[i];
+    if (arr[i] && arr[i].length && arr[i][0] !== '#') return arr[i];
   }
 }
 

--- a/test/detect-inputtype.js
+++ b/test/detect-inputtype.js
@@ -7,6 +7,7 @@ var detect = require('../lib/detect-inputtype')
 
 var instruments = fs.readFileSync(__dirname + '/fixtures/instruments-part1.csv').toString().split('\n')
 var perf = fs.readFileSync(__dirname + '/fixtures/perf-script-part1.txt').toString().split('\n')
+var commentedPerf = fs.readFileSync(__dirname + '/fixtures/perf-script-commented.txt').toString().split('\n')
 
 test('\ninput detector', function (t) {
   t.equal(detect([]), null, 'returns null for empty array')
@@ -14,5 +15,7 @@ test('\ninput detector', function (t) {
 
   t.equal(detect(instruments), 'instruments', 'detects instruments csv')
   t.equal(detect(perf), 'perf', 'detects file generated via `perf script`')
+
+  t.equal(detect(commentedPerf), 'perf', 'detects file generated via `perf script` with header comments')
   t.end()
 })

--- a/test/fixtures/perf-script-commented.txt
+++ b/test/fixtures/perf-script-commented.txt
@@ -1,0 +1,52 @@
+# ========
+# captured on: Fri Jan  9 13:16:21 2015
+# hostname : plumm
+# os release : 3.11.0-12-generic
+# perf version : 
+# arch : x86_64
+# nrcpus online : 4
+# nrcpus avail : 4
+# cpudesc : Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
+# total memory : 7861652 kB
+# cmdline : /usr/lib/linux-tools-3.11.0-12/perf record -e cycles:u -g -- node --perf-basic-prof faas.js 
+# event : name = cycles:u, type = 0, config = 0x0, config1 = 0x0, config2 = 0x0, excl_usr = 0, excl_kern = 1, excl_host = 0, excl_guest = 0, precise_ip = 0
+# HEADER_CPU_TOPOLOGY info available, use -I to display
+# HEADER_NUMA_TOPOLOGY info available, use -I to display
+# pmu mappings: cpu = 4, software = 1, tracepoint = 2, breakpoint = 5
+# ========
+#
+node 22610 13108.211038: cpu-clock:u: 
+	          9d8a7a v8::internal::Zone::Zone(v8::internal::Isolate*) (/usr/local/bin/node)
+	          8a527a v8::internal::LChunk::MarkEmptyBlocks() (/usr/local/bin/node)
+	          8a5e07 v8::internal::LChunk::Codegen() (/usr/local/bin/node)
+	          73ed1d v8::internal::ArraySingleArgumentConstructorStub::GenerateCode() (/usr/local/bin/node)
+	          7399b9 v8::internal::CodeStub::GetCode() (/usr/local/bin/node)
+	          9ee776 v8::internal::ArrayConstructorStubBase::GenerateStubsAheadOfTime(v8::internal::Isolate*) (/usr/local/bin/node)
+	          9ee5ca v8::internal::CodeStub::GenerateStubsAheadOfTime(v8::internal::Isolate*) (/usr/local/bin/node)
+	          7e582a v8::internal::Heap::CreateInitialObjects() (/usr/local/bin/node)
+	          7ebe32 v8::internal::Heap::CreateHeapObjects() (/usr/local/bin/node)
+	          886a33 v8::internal::Isolate::Init(v8::internal::Deserializer*) (/usr/local/bin/node)
+	          9d7b87 v8::internal::V8::Initialize(v8::internal::Deserializer*) (/usr/local/bin/node)
+	          70a432 v8::V8::AddMessageListener(void (*)(v8::Handle<v8::Message>, v8::Handle<v8::Value>), v8::Handle<v8::Value>) (/usr/local/bin/node)
+	          a5dcea node::Init(int*, char const**, int*, char const***) (/usr/local/bin/node)
+	          a5e660 node::Start(int, char**) (/usr/local/bin/node)
+	    7f8f7aac6ec5 __libc_start_main (/lib/x86_64-linux-gnu/libc-2.19.so)
+
+node 22610 13108.212301: cpu-clock:u: 
+	          7ffa4a v8::internal::HDeadCodeEliminationPhase::MarkLiveInstructions() (/usr/local/bin/node)
+	          8300d2 void v8::internal::HGraph::Run<v8::internal::HDeadCodeEliminationPhase>() (/usr/local/bin/node)
+	          82ffec v8::internal::HGraph::Optimize(v8::internal::BailoutReason*) (/usr/local/bin/node)
+	          74379e v8::internal::OptimizeGraph(v8::internal::HGraph*) (/usr/local/bin/node)
+	          73eef5 v8::internal::ArrayNArgumentsConstructorStub::GenerateCode() (/usr/local/bin/node)
+	          7399b9 v8::internal::CodeStub::GetCode() (/usr/local/bin/node)
+	          9ee7f6 v8::internal::ArrayConstructorStubBase::GenerateStubsAheadOfTime(v8::internal::Isolate*) (/usr/local/bin/node)
+	          9ee5ca v8::internal::CodeStub::GenerateStubsAheadOfTime(v8::internal::Isolate*) (/usr/local/bin/node)
+	          7e582a v8::internal::Heap::CreateInitialObjects() (/usr/local/bin/node)
+	          7ebe32 v8::internal::Heap::CreateHeapObjects() (/usr/local/bin/node)
+	          886a33 v8::internal::Isolate::Init(v8::internal::Deserializer*) (/usr/local/bin/node)
+	          9d7b87 v8::internal::V8::Initialize(v8::internal::Deserializer*) (/usr/local/bin/node)
+	          70a432 v8::V8::AddMessageListener(void (*)(v8::Handle<v8::Message>, v8::Handle<v8::Value>), v8::Handle<v8::Value>) (/usr/local/bin/node)
+	          a5dcea node::Init(int*, char const**, int*, char const***) (/usr/local/bin/node)
+	          a5e660 node::Start(int, char**) (/usr/local/bin/node)
+	    7f8f7aac6ec5 __libc_start_main (/lib/x86_64-linux-gnu/libc-2.19.so)
+


### PR DESCRIPTION
Some versions of the perf tool generated headers on the start of the file. While the parser recognizes this and skips those lines, the input type detector does not recognize it.

This PR fixes this, so both formats are detected.
