### PR TITLE
add command line option for mapping / symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# flamegraph [![build status](https://secure.travis-ci.org/thlorenz/flamegraph.png)](http://travis-ci.org/thlorenz/flamegraph) 
+# flamegraph [![build status](https://secure.travis-ci.org/thlorenz/flamegraph.png)](http://travis-ci.org/thlorenz/flamegraph)
 
 [![testling badge](https://ci.testling.com/thlorenz/flamegraph.png)](https://ci.testling.com/thlorenz/flamegraph)
 
@@ -29,6 +29,10 @@ OPTIONS:
 
   --inputtype -t      the type of callgraph 'instruments | perf | cpuprofile'
 
+  --file -f           the input csv file (may also be piped)
+  --output -o         the output svg file (may also be displayed in stdout)
+  --map -m            a mapping / symbols file, named perf-<pid>.map, generated using node --perf-basic-prof
+
   --fonttype          font family used                  default: 'Verdana'
   --fontsize          base text size                    default: 12
   --imagewidth        max width, pixels                 default: 1200
@@ -49,11 +53,13 @@ OPTIONS:
   --internals         include internal functions        default: false
   --optimizationinfo  include optimization indicators   default: false
 
-  --help      -h  print this help message 
+  --help      -h  print this help message
 
 EXAMPLE:
 
   cat instruments-callgraph.csv | flamegraph -t instruments > flamegraph.svg
+
+  flamegraph -t instruments -f instruments-callgraph.csv -m perf-4499.map -o flamegraph.svg
 ```
 
 The input data needs to be generated as follows:

--- a/bin/flamegraph.js
+++ b/bin/flamegraph.js
@@ -13,9 +13,9 @@ function usage() {
 }
 
 var argv = minimist(process.argv.slice(2)
-  , { boolean: [ 'h', 'help' ] 
-    , string: [ 't', 'inputtype' ]
-    }
+  , { boolean: [ 'h', 'help' ]
+  , string: [ 't', 'inputtype', 'm', 'map', 'f', 'file', 'o', 'output' ]
+  }
 );
 
 function inspect(obj, depth) {
@@ -24,4 +24,15 @@ function inspect(obj, depth) {
 
 if (argv.h || argv.help) return usage();
 
-flamegraphFromStream(process.stdin, argv).pipe(process.stdout)
+var input = process.stdin;
+if (argv.f || argv.file)
+  input = fs.createReadStream(argv.f || argv.file);
+
+var output = process.stdout;
+if (argv.o || argv.output)
+  output = fs.createWriteStream(argv.o || argv.output);
+
+if (argv.m || argv.map)
+  argv.profile = { map: fs.readFileSync(argv.m || argv.map).toString() };
+
+flamegraphFromStream(input, argv).pipe(output);


### PR DESCRIPTION
The ui wait for a `.csv` file and may take a `perf-id.map` file.
This pull request add a `--map` parameter to the command line client, so the same operation can be made with it. It also add a `--file` and  `--output` parameters so pipe and output redirect are not compulsory.

Readme file is updated accordingly.

```
flamegraph -t instruments -f instruments-callgraph.csv -m perf-4499.map -o flamegraph.svg
```
