### PR TITLE
License value fix to valid SPDX in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,7 @@
     "email": "thlorenz@gmx.de",
     "url": "http://thlorenz.com"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/thlorenz/flamegraph/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "engine": {
     "node": ">=0.10"
   },


### PR DESCRIPTION
The license value in the package.json should be a valid SPDX as documented on (https://docs.npmjs.com/files/package.json#license). This commit fixes it.
