### PR TITLE
Point generate-perf-data.md link in README to gh-pages branch. Fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ EXAMPLE:
 
 The input data needs to be generated as follows:
 
-- [use perf on linux](https://github.com/thlorenz/flamegraph/blob/master/generate-perf-data.md)
+- [use perf on linux](https://github.com/thlorenz/flamegraph/blob/gh-pages/generate-perf-data.md)
 - [use dtrace on OSX](https://github.com/thlorenz/cpuprofilify#instructions)
 
 ## API


### PR DESCRIPTION
One possible fix for #27, adjusting the present absolute link to generate-perf-data.md to point to the gh-pages branch.