### PR TITLE
Use relative link on README.md to point to generate-perf-data.md. Fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ EXAMPLE:
 
 The input data needs to be generated as follows:
 
-- [use perf on linux](https://github.com/thlorenz/flamegraph/blob/master/generate-perf-data.md)
+- [use perf on linux](./generate-perf-data.md)
 - [use dtrace on OSX](https://github.com/thlorenz/cpuprofilify#instructions)
 
 ## API


### PR DESCRIPTION
An heftier change to #28, the incorrect generate-perf-data.md link. In this fix we change the link to be relative `./generate-perf-data.md` which should make the link always resolve relative to the current branch.

Currently the link is absolute, and pointing at the master branch.